### PR TITLE
Enable Edit Feature to LogEntry Table

### DIFF
--- a/packages/client/src/components/ViewLogEntries/LogEntryModal.tsx
+++ b/packages/client/src/components/ViewLogEntries/LogEntryModal.tsx
@@ -1,10 +1,11 @@
-import { CreateLogEntryRequest } from '@mapistry/take-home-challenge-shared';
+import { CreateLogEntryRequest, LogEntryResponse } from '@mapistry/take-home-challenge-shared';
 import { ReactNode } from 'react';
 import styled from 'styled-components';
 
-interface CreateLogEntryProps {
+interface LogEntryProps {
+  logEntry?: LogEntryResponse | undefined;
   handleClose: () => void;
-  handleCreate: (logEntry: CreateLogEntryRequest) => void;
+  handleSubmit: (logEntry: CreateLogEntryRequest) => void;
 }
 
 const Modal = styled.div`
@@ -70,10 +71,22 @@ const ButtonContainer = styled.div`
   }
 `;
 
-export function CreateLogEntryModal({
+export function LogEntryModal({
+  logEntry = undefined,
   handleClose,
-  handleCreate,
-}: CreateLogEntryProps) {
+  handleSubmit,
+}: LogEntryProps) {
+
+  // todo write something custom, or inject moment js to better handle timezone issues
+  function parseLogEntryDate(date: string | undefined): string{
+  if (date) {
+    const newDate = new Date(date);
+    // Format the date as YYYY-MM-DD
+    return newDate.toISOString().split('T')[0];
+  }
+  return '';
+}
+
   return (
     <Modal>
       <ModalContent>
@@ -88,21 +101,22 @@ export function CreateLogEntryModal({
               logDate: { value: string };
               logValue: { value: string };
             };
-            const logEntry = {
+            const log = {
+              ...logEntry,
               logDate: new Date(target.logDate.value),
               logValue: parseInt(target.logValue.value, 10),
             };
-            handleCreate(logEntry);
+            handleSubmit(log);
           }}
         >
           <label htmlFor="logDate">
             Date:&nbsp;
-            <input type="date" name="logDate" />
+            <input type="date" name="logDate" defaultValue={parseLogEntryDate(logEntry?.logDate?.toString())}/>
           </label>
 
           <label htmlFor="logValue">
             Value:&nbsp;
-            <input type="text" name="logValue" />
+            <input type="text" name="logValue" defaultValue={logEntry?.logValue || ''}/>
           </label>
           <ButtonContainer>
             <button type="button" onClick={handleClose}>
@@ -114,4 +128,8 @@ export function CreateLogEntryModal({
       </ModalContent>
     </Modal>
   );
+}
+
+LogEntryModal.defaultProps = {
+  logEntry: undefined
 }

--- a/packages/client/src/components/ViewLogEntries/ViewLogEntries.tsx
+++ b/packages/client/src/components/ViewLogEntries/ViewLogEntries.tsx
@@ -5,7 +5,7 @@ import { useLogEntries } from '../../hooks/useLogEntries';
 import { createLogEntry } from '../../shared/apiClient/logsApi';
 import { Error } from '../shared/Error';
 import { Loading } from '../shared/Loading';
-import { CreateLogEntryModal } from './CreateLogEntryModal';
+import { LogEntryModal } from './LogEntryModal';
 import { ViewLogEntriesEmptyPage } from './ViewLogEntriesEmptyPage';
 import { ViewLogEntriesHeader } from './ViewLogEntriesHeader';
 import { ViewLogEntriesTable } from './ViewLogEntriesTable';
@@ -57,9 +57,9 @@ export function ViewLogEntries() {
   return (
     <Container>
       {isCreateEntryOpen && (
-        <CreateLogEntryModal
+        <LogEntryModal
           handleClose={handleCloseModal}
-          handleCreate={handleCreateLogEntry}
+          handleSubmit={handleCreateLogEntry}
         />
       )}
       <ViewLogEntriesHeader

--- a/packages/client/src/components/ViewLogEntries/ViewLogEntriesTable.tsx
+++ b/packages/client/src/components/ViewLogEntries/ViewLogEntriesTable.tsx
@@ -2,7 +2,7 @@ import { LogEntryResponse } from '@mapistry/take-home-challenge-shared';
 import { useCallback } from 'react';
 import styled from 'styled-components';
 import { useLogEntries } from '../../hooks/useLogEntries';
-import { deleteLogEntry } from '../../shared/apiClient/logsApi';
+import { deleteLogEntry, editLogEntry } from '../../shared/apiClient/logsApi';
 
 interface ViewLogEntriesTableProps {
   logId: string;
@@ -37,6 +37,16 @@ export function ViewLogEntriesTable({ logId }: ViewLogEntriesTableProps) {
     [refreshLogEntries],
   );
 
+  const handleEdit = useCallback(
+    async (logEntry) => {
+      const update = logEntry;
+      update.logValue = Math.floor(Math.random() * 30);
+      await editLogEntry(update);
+      refreshLogEntries();
+    },
+    [refreshLogEntries],
+  );
+
   function columns() {
     return (
       <thead>
@@ -52,7 +62,7 @@ export function ViewLogEntriesTable({ logId }: ViewLogEntriesTableProps) {
   function actions(logEntry: LogEntryResponse) {
     return (
       <div>
-        <button type="button" style={{ marginRight: '0.5rem' }}>
+        <button type="button" style={{ marginRight: '0.5rem' }} onClick={() => handleEdit(logEntry)}>
           Edit
         </button>
         <button type="button" onClick={() => handleDelete(logEntry)}>

--- a/packages/client/src/components/ViewLogEntries/ViewLogEntriesTable.tsx
+++ b/packages/client/src/components/ViewLogEntries/ViewLogEntriesTable.tsx
@@ -1,7 +1,8 @@
 import { LogEntryResponse } from '@mapistry/take-home-challenge-shared';
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import styled from 'styled-components';
 import { useLogEntries } from '../../hooks/useLogEntries';
+import { LogEntryModal } from './LogEntryModal';
 import { deleteLogEntry, editLogEntry } from '../../shared/apiClient/logsApi';
 
 interface ViewLogEntriesTableProps {
@@ -25,6 +26,10 @@ const StyledTable = styled.table`
 `;
 
 export function ViewLogEntriesTable({ logId }: ViewLogEntriesTableProps) {
+
+  const [isEditEntryOpen, setIsEditEntryOpen] = useState(false);
+  const [logEntryToEdit, setLogEntryToEdit] = useState<LogEntryResponse|undefined>(undefined);
+
   const { logEntries, refreshLogEntries } = useLogEntries({ logId });
   const handleDelete = useCallback(
     async (logEntry) => {
@@ -37,11 +42,15 @@ export function ViewLogEntriesTable({ logId }: ViewLogEntriesTableProps) {
     [refreshLogEntries],
   );
 
+  const handleCloseModal = useCallback(() => {
+    setIsEditEntryOpen(false);
+    setLogEntryToEdit(undefined);
+  }, [setIsEditEntryOpen]);
+
   const handleEdit = useCallback(
     async (logEntry) => {
-      const update = logEntry;
-      update.logValue = Math.floor(Math.random() * 30);
-      await editLogEntry(update);
+      await editLogEntry(logEntry);
+      setIsEditEntryOpen(false)
       refreshLogEntries();
     },
     [refreshLogEntries],
@@ -62,7 +71,10 @@ export function ViewLogEntriesTable({ logId }: ViewLogEntriesTableProps) {
   function actions(logEntry: LogEntryResponse) {
     return (
       <div>
-        <button type="button" style={{ marginRight: '0.5rem' }} onClick={() => handleEdit(logEntry)}>
+        <button type="button" style={{ marginRight: '0.5rem' }} onClick={() => {
+          setLogEntryToEdit(logEntry)
+          setIsEditEntryOpen(true)
+        }}>
           Edit
         </button>
         <button type="button" onClick={() => handleDelete(logEntry)}>
@@ -88,6 +100,13 @@ export function ViewLogEntriesTable({ logId }: ViewLogEntriesTableProps) {
 
   return (
     <div>
+      {isEditEntryOpen && (
+        <LogEntryModal
+          logEntry={logEntryToEdit}
+          handleClose={handleCloseModal}
+          handleSubmit={handleEdit}
+        />
+      )}
       <StyledTable>
         {columns()}
         {rows()}

--- a/packages/client/src/shared/apiClient/logsApi.ts
+++ b/packages/client/src/shared/apiClient/logsApi.ts
@@ -57,3 +57,18 @@ export async function deleteLogEntry(logEntry: LogEntryResponse) {
     throw new Error('Failed to delete log entry');
   }
 }
+
+
+export async function editLogEntry(logEntry: LogEntryResponse) {
+  const { logId, id } = logEntry;
+  const res = await fetch(`/api/logs/${logId}/log-entries/${id}`, {
+    body: JSON.stringify({ logEntry }),
+    method: 'PATCH',
+    headers: {
+      'content-type': 'application/json',
+    },
+  });
+  if (!res.ok) {
+    throw new Error('Failed to edit log entry');
+  }
+}

--- a/packages/server/src/application/services/LogEntriesService.test.ts
+++ b/packages/server/src/application/services/LogEntriesService.test.ts
@@ -78,7 +78,7 @@ describe('LogEntriesService', () => {
         id: '-1',
         logId: LOG_3_ID,
         logDate: new Date('2024-01-01'),
-        logValue: 999,
+        logValue: 999, // todo assert off prior value to check for change
       };
       [entryToEdit] = await Database.getAllLogEntries(LOG_3_ID);
       await subject.editLogEntry(LOG_3_ID, entryToEdit!.id, editEntry);

--- a/packages/server/src/application/services/LogEntriesService.test.ts
+++ b/packages/server/src/application/services/LogEntriesService.test.ts
@@ -87,7 +87,7 @@ describe('LogEntriesService', () => {
     it('edits the log entry for the given id', async () => {
       const allEntries = await subject.getLogEntries(LOG_3_ID);
       expect(allEntries).toHaveLength(1);
-      expect(allEntries.find((le) => le.logValue === 999)).toBeFalsy();
+      expect(allEntries.find((le) => le.logValue === 999)).toBeTruthy();
     });
 
   });

--- a/packages/server/src/application/services/LogEntriesService.test.ts
+++ b/packages/server/src/application/services/LogEntriesService.test.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 import {
   LOG_2_ID,
-  LogEntryResponse,
+  LOG_3_ID,
+  LogEntryResponse
 } from '@mapistry/take-home-challenge-shared';
 import { Database, LogEntriesRecord } from '../../shared/database';
 import { LogEntriesService } from './LogEntriesService';
@@ -66,5 +67,28 @@ describe('LogEntriesService', () => {
     it('returns the deleted log entry id', () => {
       expect(result).toBe(entryToDelete!.id);
     });
+  });
+
+  describe('editLogEntry', () => {
+
+    let entryToEdit: LogEntriesRecord | undefined;
+
+    beforeAll(async () => {
+      const editEntry: LogEntriesRecord = {
+        id: '-1',
+        logId: LOG_3_ID,
+        logDate: new Date('2024-01-01'),
+        logValue: 999,
+      };
+      [entryToEdit] = await Database.getAllLogEntries(LOG_3_ID);
+      await subject.editLogEntry(LOG_3_ID, entryToEdit!.id, editEntry);
+    });
+
+    it('edits the log entry for the given id', async () => {
+      const allEntries = await subject.getLogEntries(LOG_3_ID);
+      expect(allEntries).toHaveLength(1);
+      expect(allEntries.find((le) => le.logValue === 999)).toBeFalsy();
+    });
+
   });
 });

--- a/packages/server/src/application/services/LogEntriesService.ts
+++ b/packages/server/src/application/services/LogEntriesService.ts
@@ -2,6 +2,7 @@ import {
   CreateLogEntryRequest,
   LogEntryResponse,
 } from '@mapistry/take-home-challenge-shared';
+import { LogEntriesRecord } from '../../shared/database';
 import { LogEntriesQueryRepository } from '../../persistence/repositories/LogEntriesQueryRepository';
 import { LogEntriesRepository } from '../../persistence/repositories/LogEntriesRepository';
 import { LogEntriesApiMapper } from '../mappers/LogEntriesApiMapper';
@@ -27,5 +28,11 @@ export class LogEntriesService {
     const logEntryRepository = new LogEntriesRepository(logId);
     const logEntry = await logEntryRepository.findById(logEntryId);
     return logEntryRepository.destroyLogEntry(logEntry);
+  }
+
+  async editLogEntry(logId: string, logEntryId: string, updateLogEntryRequest: LogEntriesRecord): Promise<string> {
+    const logEntryRepository = new LogEntriesRepository(logId);
+    const logEntry = await logEntryRepository.findById(logEntryId);
+    return logEntryRepository.editLogEntry(logEntry.id.value, updateLogEntryRequest);
   }
 }

--- a/packages/server/src/persistence/repositories/LogEntriesRepository.ts
+++ b/packages/server/src/persistence/repositories/LogEntriesRepository.ts
@@ -1,5 +1,5 @@
 import { LogEntry } from '../../domain/entities/LogEntry';
-import { Database } from '../../shared/database';
+import { Database, LogEntriesRecord } from '../../shared/database';
 import { RecordNotFoundError } from '../../shared/errors';
 import { LogEntriesPersistenceMapper } from '../mappers/LogEntriesPersistenceMapper';
 
@@ -25,5 +25,10 @@ export class LogEntriesRepository {
   async destroyLogEntry(logEntry: LogEntry): Promise<string> {
     await Database.deleteLogEntry(logEntry.id.value);
     return logEntry.id.value;
+  }
+
+  async editLogEntry(logEntryId: string, updateLogEntryRequest: LogEntriesRecord): Promise<string> {
+    const log = await Database.editLogEntry(logEntryId, updateLogEntryRequest);
+    return log;
   }
 }

--- a/packages/server/src/persistence/repositories/LogEntriesRepository.ts
+++ b/packages/server/src/persistence/repositories/LogEntriesRepository.ts
@@ -28,7 +28,7 @@ export class LogEntriesRepository {
   }
 
   async editLogEntry(logEntryId: string, updateLogEntryRequest: LogEntriesRecord): Promise<string> {
-    const log = await Database.editLogEntry(logEntryId, updateLogEntryRequest);
-    return log;
+    const logId = await Database.editLogEntry(logEntryId, updateLogEntryRequest);
+    return logId;
   }
 }

--- a/packages/server/src/presentation/controllers/logEntriesController.ts
+++ b/packages/server/src/presentation/controllers/logEntriesController.ts
@@ -12,6 +12,25 @@ logEntriesController.get('/logs/:logId/log-entries', async (req, res) => {
   res.json(logEntries);
 });
 
+
+logEntriesController.patch('/logs/:logId/log-entries/:logEntryId', async (req, res) => {
+  const { logId, logEntryId } = req.params;
+  const { logEntry } = req.body;
+  const logEntryService = new LogEntriesService();
+  try {
+    await logEntryService.editLogEntry(logId, logEntryId, logEntry);
+    res.json(logId);
+  } catch (e: unknown) {
+    if (e instanceof ValidationError) {
+      res.status(HttpStatusCode.INVALID_DATA);
+      res.send(e.toString());
+    } else {
+      res.status(HttpStatusCode.SERVER_ERROR);
+      res.send();
+    }
+  }
+});
+
 logEntriesController.put('/logs/:logId/log-entries', async (req, res) => {
   const { logId } = req.params;
   const { logEntry } = req.body;

--- a/packages/server/src/shared/database.ts
+++ b/packages/server/src/shared/database.ts
@@ -91,13 +91,12 @@ export class Database {
     await this.simulateDbSlowness();
     const db = await fs.readFileSync(FILE_NAME, 'utf8');
     const allEntries = JSON.parse(db) as LogEntriesRecord[];
-    const index = allEntries.findIndex((le) => le.id === logEntryId);
     
     // validation; error out, if index is not found
+    const index = allEntries.findIndex((le) => le.id === logEntryId);
 
-    let recordToUpdate = allEntries[index];
-    recordToUpdate = updateLogEntryRequest; // overwrite/edit action
-    recordToUpdate.updatedAt = new Date();
+    allEntries[index] = updateLogEntryRequest; // overwrite/edit action
+    allEntries[index].updatedAt = new Date();
     await fs.writeFileSync(FILE_NAME, JSON.stringify(allEntries));
     return logEntryId;
   }

--- a/packages/server/src/shared/database.ts
+++ b/packages/server/src/shared/database.ts
@@ -1,4 +1,4 @@
-import { LOG_1_ID, LOG_2_ID } from '@mapistry/take-home-challenge-shared';
+import { LOG_1_ID, LOG_2_ID, LOG_3_ID } from '@mapistry/take-home-challenge-shared';
 import crypto from 'crypto';
 import fs from 'fs';
 
@@ -7,6 +7,7 @@ export type LogEntriesRecord = {
   logId: string;
   logDate: Date;
   logValue: number;
+  updatedAt?: Date;
 };
 
 const LOG_ENTRIES_TABLE_SEED: LogEntriesRecord[] = [
@@ -33,6 +34,12 @@ const LOG_ENTRIES_TABLE_SEED: LogEntriesRecord[] = [
     logId: LOG_2_ID,
     logDate: new Date('2024-01-01'),
     logValue: 15,
+  },
+  {
+    id: crypto.randomUUID().toString(),
+    logId: LOG_3_ID,
+    logDate: new Date('2025-02-18'),
+    logValue: 25,
   },
 ];
 
@@ -80,6 +87,22 @@ export class Database {
     return logEntryId;
   }
 
+  public static async editLogEntry(logEntryId: string, updateLogEntryRequest: LogEntriesRecord): Promise<string> {
+    await this.simulateDbSlowness();
+    const db = await fs.readFileSync(FILE_NAME, 'utf8');
+    const allEntries = JSON.parse(db) as LogEntriesRecord[];
+    const index = allEntries.findIndex((le) => le.id === logEntryId);
+    
+    // validation; error out, if index is not found
+
+    let recordToUpdate = allEntries[index];
+    recordToUpdate = updateLogEntryRequest; // overwrite/edit action
+    recordToUpdate.updatedAt = new Date();
+    await fs.writeFileSync(FILE_NAME, JSON.stringify(allEntries));
+    return logEntryId;
+  }
+
+  // haha, interesting
   private static simulateDbSlowness(ms = 1000) {
     return new Promise((resolve) => {
       setTimeout(resolve, ms);

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,3 +1,4 @@
 export const PROJECT_ID = '987zyx';
 export const LOG_1_ID = 'abc123';
 export const LOG_2_ID = 'def456';
+export const LOG_3_ID = 'hij789';


### PR DESCRIPTION
### Story
We would like you to add the ability to _edit_ existing log entries.

### Test Instructions
1. Start up the server `yarn workspace @mapistry/take-home-challenge-server start`
2. Start up the client `yarn workspace @mapistry/take-home-challenge-client start`
3. Browse to `http://localhost:3001/`
4. Click the `Edit` Button
5. You have three possible actions; Cancel, Close (X button), and Save
6. Cancel and Close should bring you back to the original state / page.
7. Save should take your changes and submit them to the server. (Loading is not implemented, so update will appear slow)

### Introduced issue
Bug with Date formatting when updating the value. Didn't want to spend a lot of time correcting that offset for now. 

### Demonstration
https://github.com/user-attachments/assets/a6da1862-b62b-4b9c-91ec-019eea710f42

Small callout; the first entry I edit doesn't appear to change because I wasn't waiting long enough and I went to edit the second row very quickly. It updates in the background, while I'm in the modal for a second time. 

